### PR TITLE
Feature/vs 78 optimize ip range filtered virtual column in druid ip range filter

### DIFF
--- a/src/main/java/bi/deep/entity/IPSetContents.java
+++ b/src/main/java/bi/deep/entity/IPSetContents.java
@@ -1,42 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package bi.deep.entity;
 
 import bi.deep.range.IPBoundedRange;
 import inet.ipaddr.IPAddress;
-
-import javax.annotation.Nullable;
 import java.util.List;
+import javax.annotation.Nullable;
 
+public class IPSetContents {
 
-public class IPSetContents
-{
+    @Nullable
+    private final List<IPAddress> ipAddresses;
 
-  @Nullable
-  private final List<IPAddress> ipAddresses;
-  @Nullable
+    @Nullable
+    private final List<IPBoundedRange> ranges;
 
-  private final List<IPBoundedRange> ranges;
-
-  public IPSetContents(@Nullable List<IPAddress> ipAddresses, @Nullable List<IPBoundedRange> ranges)
-  {
-    this.ipAddresses = ipAddresses;
-    this.ranges = ranges;
-  }
-
-  @Nullable
-  public List<IPBoundedRange> getRanges()
-  {
-    return ranges;
-  }
-
-  public boolean containsAnyIP(List<IPAddress> candidates, boolean ignoreVersionMismatch)
-  {
-    for (IPAddress ip : candidates) {
-      if (ipAddresses != null && !ipAddresses.isEmpty() && ipAddresses
-              .contains(ip)) {
-        return true;
-      }
+    public IPSetContents(@Nullable List<IPAddress> ipAddresses, @Nullable List<IPBoundedRange> ranges) {
+        this.ipAddresses = ipAddresses;
+        this.ranges = ranges;
     }
-    return ranges != null && ranges.stream()
-            .anyMatch(r -> r.containsAnyIP(candidates, ignoreVersionMismatch));
-  }
+
+    @Nullable
+    public List<IPBoundedRange> getRanges() {
+        return ranges;
+    }
+
+    public boolean containsAnyIP(List<IPAddress> candidates, boolean ignoreVersionMismatch) {
+        for (IPAddress ip : candidates) {
+            if (ipAddresses != null && !ipAddresses.isEmpty() && ipAddresses.contains(ip)) {
+                return true;
+            }
+        }
+        return ranges != null && ranges.stream().anyMatch(r -> r.containsAnyIP(candidates, ignoreVersionMismatch));
+    }
 }

--- a/src/main/java/bi/deep/filtering/common/IPAddressRangeListPredicateFactory.java
+++ b/src/main/java/bi/deep/filtering/common/IPAddressRangeListPredicateFactory.java
@@ -21,7 +21,6 @@ package bi.deep.filtering.common;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-
 import org.apache.druid.query.filter.DruidDoublePredicate;
 import org.apache.druid.query.filter.DruidFloatPredicate;
 import org.apache.druid.query.filter.DruidLongPredicate;
@@ -65,9 +64,7 @@ public class IPAddressRangeListPredicateFactory implements DruidPredicateFactory
             if (arr == null) {
                 return DruidPredicateMatch.FALSE;
             }
-            String mvs = Arrays.stream(arr)
-                    .map(String::valueOf)
-                    .collect(Collectors.joining(","));
+            String mvs = Arrays.stream(arr).map(String::valueOf).collect(Collectors.joining(","));
             return predicate.apply(mvs);
         };
     }

--- a/src/main/java/bi/deep/matching/IPRangeFilteredDimensionSelector.java
+++ b/src/main/java/bi/deep/matching/IPRangeFilteredDimensionSelector.java
@@ -37,7 +37,7 @@ import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.data.ZeroIndexedInts;
 
 public class IPRangeFilteredDimensionSelector extends AbstractDimensionSelector {
-
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger log = new Logger(IPRangeFilteredDimensionSelector.class);
 
     protected final DimensionSelector baseSelector;
@@ -69,7 +69,7 @@ public class IPRangeFilteredDimensionSelector extends AbstractDimensionSelector 
                 if (extractionResult.startsWith("[") && extractionResult.endsWith("]")) {
                     try {
                         List<String> array =
-                                new ObjectMapper().readValue(extractionResult, new TypeReference<List<String>>() {});
+                                OBJECT_MAPPER.readValue(extractionResult, new TypeReference<List<String>>() {});
                         return array.stream().anyMatch(x -> (includeUnknown && x == null) || Objects.equals(x, value));
                     } catch (IOException e) {
                         log.warn(e, "Failed to parse JSON array, returning false: %s", extractionResult);
@@ -101,7 +101,7 @@ public class IPRangeFilteredDimensionSelector extends AbstractDimensionSelector 
                 if (extractionResult.startsWith("[") && extractionResult.endsWith("]")) {
                     try {
                         List<String> elements =
-                                new ObjectMapper().readValue(extractionResult, new TypeReference<List<String>>() {});
+                                OBJECT_MAPPER.readValue(extractionResult, new TypeReference<List<String>>() {});
                         return elements.stream()
                                 .anyMatch(x -> predicate.apply(x).matches(includeUnknown));
                     } catch (IOException e) {

--- a/src/main/java/bi/deep/matching/IPRangeFilteredDimensionSpec.java
+++ b/src/main/java/bi/deep/matching/IPRangeFilteredDimensionSpec.java
@@ -49,10 +49,8 @@ public class IPRangeFilteredDimensionSpec implements DimensionSpec {
         this.ips = ips;
     }
 
-    public static DimensionSelector makeDimensionSelector(
-            Set<String> values, DimensionSelector valueSelector) {
-        return new IPRangeFilteredDimensionSelector(
-                valueSelector, new IPRangeFilteredExtractionFn(values));
+    public static DimensionSelector makeDimensionSelector(Set<String> values, DimensionSelector valueSelector) {
+        return new IPRangeFilteredDimensionSelector(valueSelector, new IPRangeFilteredExtractionFn(values));
     }
 
     @JsonProperty("delegate")
@@ -69,7 +67,6 @@ public class IPRangeFilteredDimensionSpec implements DimensionSpec {
     public String getDimension() {
         return delegate.getDimension();
     }
-
 
     @Override
     @JsonProperty("name")

--- a/src/main/java/bi/deep/matching/IPRangeFilteredVirtualColumn.java
+++ b/src/main/java/bi/deep/matching/IPRangeFilteredVirtualColumn.java
@@ -76,8 +76,7 @@ public class IPRangeFilteredVirtualColumn implements VirtualColumn {
 
     @Override
     public DimensionSelector makeDimensionSelector(DimensionSpec dimensionSpec, ColumnSelectorFactory factory) {
-        return IPRangeFilteredDimensionSpec.makeDimensionSelector(
-                ips, factory.makeDimensionSelector(delegate));
+        return IPRangeFilteredDimensionSpec.makeDimensionSelector(ips, factory.makeDimensionSelector(delegate));
     }
 
     @Override

--- a/src/main/java/bi/deep/util/IPRangeUtil.java
+++ b/src/main/java/bi/deep/util/IPRangeUtil.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package bi.deep.util;
 
 import bi.deep.entity.IPSetContents;
@@ -26,9 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressSeqRange;
 import inet.ipaddr.IPAddressString;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.druid.common.config.NullHandling;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,97 +34,93 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.druid.common.config.NullHandling;
 
-public class IPRangeUtil
-{
-  private static final String DASH_REGEX = "^([0-9A-Fa-f:.]+)[–-]([0-9A-Fa-f:.]+)$";
-  private static final String SLASH_REGEX = "^([0-9A-Fa-f:.]+)/([0-9A-Fa-f:.]+)$";
-  private static final String CIDR_REGEX = "^[0-9A-Fa-f:.]+/\\d+$";
-  private static final String IP_REGEX = "^[0-9A-Fa-f:.]+$";
+public class IPRangeUtil {
+    private static final String DASH_REGEX = "^([0-9A-Fa-f:.]+)[–-]([0-9A-Fa-f:.]+)$";
+    private static final String SLASH_REGEX = "^([0-9A-Fa-f:.]+)/([0-9A-Fa-f:.]+)$";
+    private static final String CIDR_REGEX = "^[0-9A-Fa-f:.]+/\\d+$";
+    private static final String IP_REGEX = "^[0-9A-Fa-f:.]+$";
 
-  public static IPSetContents extractIPSetContents(String input)
-  {
-    List<IPAddress> ips = new ArrayList<>();
-    List<IPBoundedRange> ranges = new ArrayList<>();
+    public static IPSetContents extractIPSetContents(String input) {
+        List<IPAddress> ips = new ArrayList<>();
+        List<IPBoundedRange> ranges = new ArrayList<>();
 
-    for (String token : input.split("\\s*,\\s*")) {
-        if (token.isEmpty()) {
-            continue;
+        for (String token : input.split("\\s*,\\s*")) {
+            if (token.isEmpty()) {
+                continue;
+            }
+
+            if (token.matches(DASH_REGEX)) {
+                Matcher m = Pattern.compile(DASH_REGEX).matcher(token);
+                if (m.matches()) {
+                    String lo = m.group(1);
+                    String hi = m.group(2);
+                    IPAddress la = new IPAddressString(lo).getAddress();
+                    IPAddress ha = new IPAddressString(hi).getAddress();
+                    if (la != null && ha != null && la.getIPVersion() == ha.getIPVersion()) {
+                        ranges.add(new IPBoundedRange(lo, hi, false, false));
+                    }
+                }
+                continue;
+            }
+
+            if (token.matches(SLASH_REGEX) && !token.matches(CIDR_REGEX)) {
+                Matcher m = Pattern.compile(SLASH_REGEX).matcher(token);
+                if (m.matches()) {
+                    String lo = m.group(1);
+                    String hi = m.group(2);
+                    ranges.add(new IPBoundedRange(lo, hi, false, false));
+                }
+                continue;
+            }
+
+            if (token.matches(CIDR_REGEX)) {
+                IPAddressSeqRange seq = new IPAddressString(token).getAddress().toSequentialRange();
+                if (seq != null) {
+                    ranges.add(new IPBoundedRange(seq, false, false));
+                }
+                continue;
+            }
+
+            if (token.matches(IP_REGEX)) {
+                IPAddress addr = new IPAddressString(token).getAddress();
+                if (addr != null) {
+                    ips.add(addr);
+                }
+            }
         }
 
-      if (token.matches(DASH_REGEX)) {
-        Matcher m = Pattern.compile(DASH_REGEX).matcher(token);
-        if (m.matches()) {
-          String lo = m.group(1);
-          String hi = m.group(2);
-          IPAddress la = new IPAddressString(lo).getAddress();
-          IPAddress ha = new IPAddressString(hi).getAddress();
-          if (la != null && ha != null && la.getIPVersion() == ha.getIPVersion()) {
-            ranges.add(new IPBoundedRange(lo, hi, false, false));
-          }
-        }
-        continue;
-      }
-
-      if (token.matches(SLASH_REGEX) && !token.matches(CIDR_REGEX)) {
-        Matcher m = Pattern.compile(SLASH_REGEX).matcher(token);
-        if (m.matches()) {
-          String lo = m.group(1);
-          String hi = m.group(2);
-          ranges.add(new IPBoundedRange(lo, hi, false, false));
-        }
-        continue;
-      }
-
-      if (token.matches(CIDR_REGEX)) {
-        IPAddressSeqRange seq = new IPAddressString(token).getAddress().toSequentialRange();
-        if (seq != null) {
-          ranges.add(new IPBoundedRange(seq, false, false));
-        }
-        continue;
-      }
-
-      if (token.matches(IP_REGEX)) {
-        IPAddress addr = new IPAddressString(token).getAddress();
-        if (addr != null) {
-          ips.add(addr);
-        }
-      }
+        return new IPSetContents(ips, ranges);
     }
 
-    return new IPSetContents(ips, ranges);
-  }
-
-  public static String getMatchingIPs(String input, Set<String> ips)
-  {
-    List<String> matchingIps = mapStringsToIps(ips).stream()
-                                                   .filter(ip ->
-                                                               Optional.ofNullable(extractIPSetContents(input).getRanges())
-                                                                       .orElse(Collections.emptyList())
-                                                                       .stream()
-                                                                       .anyMatch(r -> r.contains(ip, false))
-                                                   )
-                                                   .map(IPAddress::toString)
-                                                   .collect(Collectors.toList());
-    if (matchingIps.isEmpty()) {
-      return NullHandling.sqlCompatible() ? null : StringUtils.EMPTY;
-    } else if (matchingIps.size() == 1) {
-      return matchingIps.get(0);
-    } else {
-      try {
-        return new ObjectMapper().writeValueAsString(matchingIps);
-      }
-      catch (JsonProcessingException e) {
-        throw new RuntimeException("Error converting to JSON", e);
-      }
+    public static String getMatchingIPs(String input, Set<String> ips) {
+        List<String> matchingIps = mapStringsToIps(ips).stream()
+                .filter(ip ->
+                        Optional.ofNullable(extractIPSetContents(input).getRanges())
+                                .orElse(Collections.emptyList())
+                                .stream()
+                                .anyMatch(r -> r.contains(ip, false)))
+                .map(IPAddress::toString)
+                .collect(Collectors.toList());
+        if (matchingIps.isEmpty()) {
+            return NullHandling.sqlCompatible() ? null : StringUtils.EMPTY;
+        } else if (matchingIps.size() == 1) {
+            return matchingIps.get(0);
+        } else {
+            try {
+                return new ObjectMapper().writeValueAsString(matchingIps);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Error converting to JSON", e);
+            }
+        }
     }
-  }
 
-  public static List<IPAddress> mapStringsToIps(final Set<String> ips)
-  {
-    return ips.stream()
-              .map(ip -> new IPAddressString(ip).getAddress())
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-  }
+    public static List<IPAddress> mapStringsToIps(final Set<String> ips) {
+        return ips.stream()
+                .map(ip -> new IPAddressString(ip).getAddress())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/bi/deep/util/IPRangeUtil.java
+++ b/src/main/java/bi/deep/util/IPRangeUtil.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.druid.common.config.NullHandling;
 
 public class IPRangeUtil {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Pattern DASH_REGEX = Pattern.compile("^([0-9A-Fa-f:.]+)[–-]([0-9A-Fa-f:.]+)$");
     private static final Pattern SLASH_REGEX = Pattern.compile("^([0-9A-Fa-f:.]+)/([0-9A-Fa-f:.]+)$");
     private static final Pattern CIDR_REGEX = Pattern.compile("^[0-9A-Fa-f:.]+/\\d+$");
@@ -139,7 +140,7 @@ public class IPRangeUtil {
             return matchingIps.get(0);
         } else {
             try {
-                return new ObjectMapper().writeValueAsString(matchingIps);
+                return OBJECT_MAPPER.writeValueAsString(matchingIps);
             } catch (JsonProcessingException e) {
                 throw new RuntimeException("Error converting to JSON", e);
             }

--- a/src/test/java/bi/deep/filtering/fn/IPRangeFilteredExtractionFnTest.java
+++ b/src/test/java/bi/deep/filtering/fn/IPRangeFilteredExtractionFnTest.java
@@ -1,6 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package bi.deep.filtering.fn;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import bi.deep.matching.IPRangeFilteredExtractionFn;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.druid.common.config.NullHandling;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,61 +33,50 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class IPRangeFilteredExtractionFnTest
-{
+class IPRangeFilteredExtractionFnTest {
 
-  private IPRangeFilteredExtractionFn extractionFn;
+    private IPRangeFilteredExtractionFn extractionFn;
 
-  static Stream<Arguments> provideTestCases()
-  {
-    return Stream.of(
-        Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, null, ""),
-        Arguments.of(NullHandlingMode.SQL_COMPATIBLE, null, null),
-        Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, "10.162.59.18-10.162.59.20", "10.162.59.19"),
-        Arguments.of(NullHandlingMode.SQL_COMPATIBLE, "10.161.12.13-10.161.12.15", "10.161.12.13"),
-        Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, "10.162.59.18-10.162.59.20, weird string", "10.162.59.19"),
-        Arguments.of(NullHandlingMode.SQL_COMPATIBLE, "10.161.12.13-10.161.12.15, weird string", "10.161.12.13"),
-        Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, "weird string", StringUtils.EMPTY),
-        Arguments.of(NullHandlingMode.SQL_COMPATIBLE, "weird string", null),
-        Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, "192.168.1.1", StringUtils.EMPTY),
-        Arguments.of(NullHandlingMode.SQL_COMPATIBLE, "172.16.0.1", null)
-    );
-  }
-
-  @BeforeEach
-  void setUp()
-  {
-    Set<String> testIps = new HashSet<>(Arrays.asList("10.162.59.19", "10.161.12.13"));
-    extractionFn = new IPRangeFilteredExtractionFn(testIps);
-  }
-
-  private void configureNullHandling(NullHandlingMode mode)
-  {
-    if (mode == NullHandlingMode.SQL_COMPATIBLE) {
-      NullHandling.initializeForTestsWithValues(false, false, false);
-    } else {
-      NullHandling.initializeForTestsWithValues(true, true, true);
+    static Stream<Arguments> provideTestCases() {
+        return Stream.of(
+                Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, null, ""),
+                Arguments.of(NullHandlingMode.SQL_COMPATIBLE, null, null),
+                Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, "10.162.59.18-10.162.59.20", "10.162.59.19"),
+                Arguments.of(NullHandlingMode.SQL_COMPATIBLE, "10.161.12.13-10.161.12.15", "10.161.12.13"),
+                Arguments.of(
+                        NullHandlingMode.NON_SQL_COMPATIBLE, "10.162.59.18-10.162.59.20, weird string", "10.162.59.19"),
+                Arguments.of(
+                        NullHandlingMode.SQL_COMPATIBLE, "10.161.12.13-10.161.12.15, weird string", "10.161.12.13"),
+                Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, "weird string", StringUtils.EMPTY),
+                Arguments.of(NullHandlingMode.SQL_COMPATIBLE, "weird string", null),
+                Arguments.of(NullHandlingMode.NON_SQL_COMPATIBLE, "192.168.1.1", StringUtils.EMPTY),
+                Arguments.of(NullHandlingMode.SQL_COMPATIBLE, "172.16.0.1", null));
     }
-  }
 
-  @ParameterizedTest
-  @MethodSource("provideTestCases")
-  void testApply(NullHandlingMode mode, String input, String expected)
-  {
-    configureNullHandling(mode);
-    assertEquals(expected, extractionFn.apply(input), "Unexpected extraction result");
-  }
+    @BeforeEach
+    void setUp() {
+        Set<String> testIps = new HashSet<>(Arrays.asList("10.162.59.19", "10.161.12.13"));
+        extractionFn = new IPRangeFilteredExtractionFn(testIps);
+    }
 
-  enum NullHandlingMode
-  {
-    SQL_COMPATIBLE, NON_SQL_COMPATIBLE
-  }
+    private void configureNullHandling(NullHandlingMode mode) {
+        if (mode == NullHandlingMode.SQL_COMPATIBLE) {
+            NullHandling.initializeForTestsWithValues(false, false, false);
+        } else {
+            NullHandling.initializeForTestsWithValues(true, true, true);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void testApply(NullHandlingMode mode, String input, String expected) {
+        configureNullHandling(mode);
+        assertEquals(expected, extractionFn.apply(input), "Unexpected extraction result");
+    }
+
+    enum NullHandlingMode {
+        SQL_COMPATIBLE,
+        NON_SQL_COMPATIBLE
+    }
 }

--- a/src/test/java/bi/deep/filtering/ip/range/RangeMatchingIPFilterTest.java
+++ b/src/test/java/bi/deep/filtering/ip/range/RangeMatchingIPFilterTest.java
@@ -18,21 +18,19 @@
  */
 package bi.deep.filtering.ip.range;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import bi.deep.entity.IPSetContents;
 import bi.deep.filtering.ip.range.impl.RangeMatchingIPFilterImpl;
 import bi.deep.range.IPBoundedRange;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
-
 import java.util.Collections;
-
 import org.apache.druid.query.filter.Filter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RangeMatchingIPFilterTest {
     private final IPAddress ipV4Address = new IPAddressString("39.181.2.192").getAddress();
@@ -65,45 +63,37 @@ public class RangeMatchingIPFilterTest {
                 ipV4Address.increment(diff * 2).toString(),
                 false,
                 false);
-        assertEquals(expectV4IncMatch, filterImpl.anyMatch(new IPSetContents(null, Collections.singletonList(rangeV4Inc))));
+        assertEquals(
+                expectV4IncMatch, filterImpl.anyMatch(new IPSetContents(null, Collections.singletonList(rangeV4Inc))));
 
         IPBoundedRange rangeV6Inc = new IPBoundedRange(
                 ipV6Address.increment(diff).toString(),
                 ipV6Address.increment(diff * 2).toString(),
                 false,
                 false);
-        assertEquals(expectV6IncMatch, filterImpl.anyMatch(new IPSetContents(null, Collections.singletonList(rangeV6Inc))));
+        assertEquals(
+                expectV6IncMatch, filterImpl.anyMatch(new IPSetContents(null, Collections.singletonList(rangeV6Inc))));
     }
 
     private void doIpListTest(
-            IPAddress targetIp,
-            IPAddress testIp,
-            boolean ignoreVersionMismatch,
-            boolean expectMatch
-    ) {
+            IPAddress targetIp, IPAddress testIp, boolean ignoreVersionMismatch, boolean expectMatch) {
         RangeMatchingIPFilter dimFilter = new RangeMatchingIPFilter(
-                "dimension",
-                Collections.singleton(targetIp.toString()),
-                ignoreVersionMismatch
-        );
+                "dimension", Collections.singleton(targetIp.toString()), ignoreVersionMismatch);
         RangeMatchingIPFilterImpl impl = (RangeMatchingIPFilterImpl) dimFilter.toFilter();
-        IPSetContents contents = new IPSetContents(
-                Collections.singletonList(testIp),
-                Collections.emptyList()
-        );
+        IPSetContents contents = new IPSetContents(Collections.singletonList(testIp), Collections.emptyList());
 
         if (expectMatch) {
             assertTrue(
                     impl.anyMatch(contents),
-                    () -> String.format("Expected match for %s vs %s (ignoreMismatch=%b)",
-                            testIp, targetIp, ignoreVersionMismatch)
-            );
+                    () -> String.format(
+                            "Expected match for %s vs %s (ignoreMismatch=%b)",
+                            testIp, targetIp, ignoreVersionMismatch));
         } else {
             assertFalse(
                     impl.anyMatch(contents),
-                    () -> String.format("Expected no match for %s vs %s (ignoreMismatch=%b)",
-                            testIp, targetIp, ignoreVersionMismatch)
-            );
+                    () -> String.format(
+                            "Expected no match for %s vs %s (ignoreMismatch=%b)",
+                            testIp, targetIp, ignoreVersionMismatch));
         }
     }
 


### PR DESCRIPTION
Optimized string to IPAddress evaluation. Previously, a query using the `ip_range_match` filter on `5000` rows and a column containing `500` IP addresses took `8.39s` to execute. After the optimization, execution time was reduced to `2.92s`, resulting in a `65%` performance improvement.